### PR TITLE
fix: replace node type with correct node name and add missing argument

### DIFF
--- a/launch/mars_gps.launch
+++ b/launch/mars_gps.launch
@@ -9,6 +9,7 @@
   <!-- Output Core State -->
   <arg name="full_state_out_topic" default="~full_state_out" />
   <arg name="pose_state_out_topic" default="~pose_state_out" />
+  <arg name="full_state_lite_out_topic" default="~full_state_lite_out" />
 
   <!-- Output Calibration State -->
   <arg name="gps_cal_state_out_topic" default="~gps_cal_state_out" />
@@ -17,7 +18,7 @@
   <arg name="respawn" default="false" />
 
   <!-- Launching the mars_ros single_gps_node -->
-  <node name="mars_single_gps_node" pkg="mars_ros" type="single_gps_node" clear_params="true" output="screen" respawn="$(arg respawn)">
+  <node name="mars_single_gps_node" pkg="mars_ros" type="gps_node" clear_params="true" output="screen" respawn="$(arg respawn)">
 
     <rosparam command="load" file="$(find mars_ros)/launch/config/gps_config.yaml" />
 

--- a/launch/mars_gps_template.launch
+++ b/launch/mars_gps_template.launch
@@ -11,7 +11,7 @@
     <!-- Output Core State -->
     <arg name="full_state_out_topic" default="~full_state_out" />
     <arg name="pose_state_out_topic" default="~pose_state_out" />
-    <arg name="pose_state_lite_out_topic" default="~pose_state_lite_out" />
+    <arg name="full_state_lite_out_topic" default="~full_state_lite_out" />
 
     <!-- Output Calibration State -->
     <arg name="gps_cal_state_out_topic" default="~gps_cal_state_out" />


### PR DESCRIPTION
Hi! Not really sure about the missing argument change, seems right because I get

`RLException: included file [/home/dante/weed_robot/catkin_ws/src/mars_ros/launch/mars_gps.launch] requires the 'full_state_lite_out_topic' arg to be set
The traceback for the exception was written to the log file`

when executing:

`roslaunch mars_ros mars_gps_template.launch`